### PR TITLE
Replace marzban service with panel in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
 services:
-  marzban:
-    image: gozargah/marzban:latest
-    restart: always
-    env_file: .env
+  panel:
+    image: ghcr.io/ton-bypass/panel:latest
+    restart: unless-stopped
     network_mode: host
+    env_file: .env
+    environment:
+      UVICORN_HOST: ${UVICORN_HOST:-0.0.0.0}
+      UVICORN_PORT: ${UVICORN_PORT:-8000}
     volumes:
       - /var/lib/marzban:/var/lib/marzban


### PR DESCRIPTION
This PR updates the `docker-compose.yml` file by replacing the `marzban` service with the `panel` service. It also adds necessary environment variables for configuration and changes the restart policy to `unless-stopped`.