### PR TITLE
Enhance Dependabot configuration for GitHub Actions updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "daily"
-    target-branch: "dev"
+      interval: daily
+    target-branch: dev
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev


### PR DESCRIPTION
This PR updates the Dependabot configuration to include weekly updates for GitHub Actions, in addition to the existing daily updates for Python packages. This ensures that both package types are kept up-to-date more effectively.